### PR TITLE
Skip acl enabled check when setting metadata

### DIFF
--- a/x/admin/keeper/msg_server.go
+++ b/x/admin/keeper/msg_server.go
@@ -29,7 +29,6 @@ func (k Keeper) SetMetadata(
 	accAddr, _ := sdk.AccAddressFromBech32(msg.Authority)
 	isACLAdmin := params.Permissions.SetMetadata &&
 		k.aclKeeper != nil &&
-		k.aclKeeper.Enabled(ctx) &&
 		k.aclKeeper.IsAdmin(ctx, accAddr)
 	isModuleAuth := msg.Authority == k.GetAuthority()
 


### PR DESCRIPTION
Skip ACL enabled check when setting metadata. ACL enabled is used for deployment access control